### PR TITLE
Support allOf required accross sub schemas

### DIFF
--- a/packages/serverless-typespec-generator/src/typespec.test.ts
+++ b/packages/serverless-typespec-generator/src/typespec.test.ts
@@ -337,7 +337,7 @@ describe("parseServerlessConfig", () => {
         ])
       })
     })
-    context("with array", () => {
+    context("with array schema", () => {
       it("should parse array api model correctly", () => {
         const serverless = createServerlessMock(
           [
@@ -410,6 +410,56 @@ describe("parseServerlessConfig", () => {
               {
                 statusCode: 200,
                 body: { ref: "Users" },
+              },
+            ],
+          },
+        ])
+      })
+    })
+    context("with array schema with allOf", () => {
+      it("should parse array api model correctly", () => {
+        const serverless = createServerlessMock([], {
+          request: {
+            schemas: {
+              tags: {
+                name: "Tags",
+                schema: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    allOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          slug: { type: "string" },
+                        },
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          name: { type: "string" },
+                        },
+                      },
+                      {
+                        type: "object",
+                        required: ["slug", "name"],
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        })
+        const { models } = parseServerlessConfig(serverless)
+        expect(Array.from(models.values())).toEqual<TypeSpecIR[]>([
+          {
+            kind: "alias",
+            name: "Tags",
+            type: [
+              {
+                slug: { type: "string", required: true },
+                name: { type: "string", required: true },
               },
             ],
           },

--- a/packages/serverless-typespec-generator/src/typespec/ir/convert.test.ts
+++ b/packages/serverless-typespec-generator/src/typespec/ir/convert.test.ts
@@ -68,6 +68,38 @@ describe("jsonSchemaToTypeSpecIR", () => {
       },
     })
   })
+  it("should convert a JSON schema with allOf and required to TypeSpec IR", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      allOf: [
+        {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+          },
+        },
+        {
+          type: "object",
+          properties: {
+            age: { type: "integer" },
+          },
+        },
+        {
+          type: "object",
+          required: ["id", "age"],
+        },
+      ],
+    }
+    const result = jsonSchemaToTypeSpecIR(schema, "Model")
+    expect(result).toEqual<ModelIR>({
+      kind: "model",
+      name: "Model",
+      props: {
+        id: { type: "string", required: true },
+        age: { type: "numeric", required: true },
+      },
+    })
+  })
 })
 
 describe("jsonSchemaToModelIR", () => {

--- a/tests/sls-v3/05-complex-schema.yml
+++ b/tests/sls-v3/05-complex-schema.yml
@@ -9,6 +9,14 @@ provider:
   runtime: nodejs20.x
   region: ap-northeast-1
   stage: dev
+  apiGateway:
+    request:
+      schemas:
+        tags:
+          name: Tags
+          schema:
+            type: array
+            items: ${file(./05-complex-schema/models/tag.yml)}
 
 functions:
   getPost:

--- a/tests/sls-v3/05-complex-schema/expected/main.tsp
+++ b/tests/sls-v3/05-complex-schema/expected/main.tsp
@@ -38,3 +38,8 @@ op getPosts(): {
     tags: string | string[];
   }[];
 };
+
+alias Tags = {
+  slug: string;
+  name: string;
+}[];

--- a/tests/sls-v3/05-complex-schema/models/tag.yml
+++ b/tests/sls-v3/05-complex-schema/models/tag.yml
@@ -1,0 +1,14 @@
+type: object
+allOf:
+  - type: object
+    properties:
+      slug:
+        type: string
+  - type: object
+    properties:
+      name:
+        type: string
+  - type: object
+    required:
+      - slug
+      - name


### PR DESCRIPTION
- **feat: add tags schema and model for complex schema**
- **feat: add support for allOf with required properties in jsonSchemaToModelIR**
- **feat: add support for array schema with allOf in parseServerlessConfig and convertType**
- **refactor: extract mergeAllOfObjectSchemas function for better readability and reuse**
