### PR TITLE
Introduce Serverless IR

### DIFF
--- a/packages/serverless-typespec-generator/src/ir/build-sls.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/build-sls.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { buildOperationIR } from "./build"
+import type { ServerlessFunctionIR } from "./serverless/type"
+import type { OperationIR } from "./type"
+
+describe("buildOperationIR", () => {
+  it("should build operation IR correctly", () => {
+    const slsIR: ServerlessFunctionIR = {
+      kind: "function",
+      name: "hello",
+      event: {
+        method: "get",
+        path: "/hello",
+      },
+    }
+
+    const result = buildOperationIR(slsIR)
+    expect(result).toEqual<OperationIR>({
+      kind: "operation",
+      name: "hello",
+      method: "get",
+      route: "/hello",
+    })
+  })
+})

--- a/packages/serverless-typespec-generator/src/ir/build-sls.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/build-sls.test.ts
@@ -1,7 +1,61 @@
 import { describe, expect, it } from "vitest"
-import { buildOperationIR } from "./build"
-import type { ServerlessFunctionIR } from "./serverless/type"
-import type { OperationIR } from "./type"
+import { buildOperationIR, buildTypeSpecIR } from "./build"
+import type { ServerlessFunctionIR, ServerlessIR } from "./serverless/type"
+import type { OperationIR, TypeSpecIR } from "./type"
+
+describe("buildTypeSpecIR", () => {
+  it("should build the TypeSpec IR", () => {
+    const slsIR: ServerlessIR[] = [
+      {
+        kind: "function",
+        name: "hello",
+        event: {
+          method: "get",
+          path: "/hello",
+        },
+      },
+    ]
+    const result = buildTypeSpecIR(slsIR)
+    expect(result).toEqual<TypeSpecIR[]>([
+      {
+        kind: "operation",
+        name: "hello",
+        method: "get",
+        route: "/hello",
+      },
+    ])
+  })
+  it("should handle functions with request models", () => {
+    const slsIR: ServerlessIR[] = [
+      {
+        kind: "function",
+        name: "hello",
+        event: {
+          method: "post",
+          path: "/hello",
+          request: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+            },
+          },
+        },
+      },
+    ]
+    const result = buildTypeSpecIR(slsIR)
+    expect(result).toEqual<TypeSpecIR[]>([
+      {
+        kind: "operation",
+        name: "hello",
+        method: "post",
+        route: "/hello",
+        requestBody: {
+          name: { type: "string", required: false },
+        },
+      },
+    ])
+  })
+})
 
 describe("buildOperationIR", () => {
   it("should build operation IR correctly", () => {

--- a/packages/serverless-typespec-generator/src/ir/build-sls.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/build-sls.test.ts
@@ -34,6 +34,7 @@ describe("buildTypeSpecIR", () => {
           method: "post",
           path: "/hello",
           request: {
+            title: "HelloRequest",
             type: "object",
             properties: {
               name: { type: "string" },
@@ -49,7 +50,12 @@ describe("buildTypeSpecIR", () => {
         name: "hello",
         method: "post",
         route: "/hello",
-        requestBody: {
+        requestBody: { ref: "HelloRequest" },
+      },
+      {
+        kind: "model",
+        name: "HelloRequest",
+        props: {
           name: { type: "string", required: false },
         },
       },
@@ -84,7 +90,6 @@ describe("buildOperationIR", () => {
         method: "post",
         path: "/hello",
         request: {
-          title: "User",
           type: "object",
           properties: {
             name: { type: "string" },
@@ -104,6 +109,33 @@ describe("buildOperationIR", () => {
         name: { type: "string", required: true },
         email: { type: "string", required: true },
       },
+    })
+  })
+  it("should build operation IR with named request schema", () => {
+    const slsIR: ServerlessFunctionIR = {
+      kind: "function",
+      name: "hello",
+      event: {
+        method: "get",
+        path: "/hello",
+        request: {
+          title: "User",
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            email: { type: "string" },
+          },
+          required: ["name", "email"],
+        },
+      },
+    }
+    const result = buildOperationIR(slsIR)
+    expect(result).toEqual<OperationIR>({
+      kind: "operation",
+      name: "hello",
+      method: "get",
+      route: "/hello",
+      requestBody: { ref: "User" },
     })
   })
 })

--- a/packages/serverless-typespec-generator/src/ir/build-sls.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/build-sls.test.ts
@@ -22,4 +22,34 @@ describe("buildOperationIR", () => {
       route: "/hello",
     })
   })
+  it("should build operation IR with request schema", () => {
+    const slsIR: ServerlessFunctionIR = {
+      kind: "function",
+      name: "hello",
+      event: {
+        method: "post",
+        path: "/hello",
+        request: {
+          title: "User",
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            email: { type: "string" },
+          },
+          required: ["name", "email"],
+        },
+      },
+    }
+    const result = buildOperationIR(slsIR)
+    expect(result).toEqual<OperationIR>({
+      kind: "operation",
+      name: "hello",
+      method: "post",
+      route: "/hello",
+      requestBody: {
+        name: { type: "string", required: true },
+        email: { type: "string", required: true },
+      },
+    })
+  })
 })

--- a/packages/serverless-typespec-generator/src/ir/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/build.ts
@@ -1,7 +1,7 @@
 import { Registry } from "./../registry"
 import type { Serverless } from "./../types/serverless"
 import { NotImplementedError } from "./error"
-import type { ServerlessFunctionIR } from "./serverless/type"
+import type { ServerlessFunctionIR, ServerlessIR } from "./serverless/type"
 import type {
   HttpResponseIR,
   JSONSchema,
@@ -273,15 +273,27 @@ export function convertType(schema: JSONSchema): PropTypeIR {
   }
 }
 
-export function buildOperationIR(slsIR: ServerlessFunctionIR): OperationIR {
+export function buildTypeSpecIR(sls: ServerlessIR[]): TypeSpecIR[] {
+  return sls.map((ir) => {
+    if (ir.kind === "function") {
+      return buildOperationIR(ir)
+    }
+
+    throw new NotImplementedError(
+      `Unsupported IR kind: ${ir.kind}. Only "function" kind is supported.`,
+    )
+  })
+}
+
+export function buildOperationIR(func: ServerlessFunctionIR): OperationIR {
   const operation: OperationIR = {
     kind: "operation",
-    name: slsIR.name,
-    method: slsIR.event.method,
-    route: slsIR.event.path,
+    name: func.name,
+    method: func.event.method,
+    route: func.event.path,
   }
 
-  const request = slsIR.event.request
+  const request = func.event.request
   if (request) {
     if (typeof request === "string") {
       operation.requestBody = { ref: request }

--- a/packages/serverless-typespec-generator/src/ir/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/build.ts
@@ -1,6 +1,7 @@
 import { Registry } from "./../registry"
 import type { Serverless } from "./../types/serverless"
 import { NotImplementedError } from "./error"
+import type { ServerlessFunctionIR } from "./serverless/type"
 import type {
   HttpResponseIR,
   JSONSchema,
@@ -269,5 +270,14 @@ export function convertType(schema: JSONSchema): PropTypeIR {
       return [convertType(schema.items)]
     default:
       throw new Error(`Unknown type: ${schema.type}`)
+  }
+}
+
+export function buildOperationIR(slsIR: ServerlessFunctionIR): OperationIR {
+  return {
+    kind: "operation",
+    name: slsIR.name,
+    method: slsIR.event.method,
+    route: slsIR.event.path,
   }
 }

--- a/packages/serverless-typespec-generator/src/ir/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/build.ts
@@ -274,10 +274,21 @@ export function convertType(schema: JSONSchema): PropTypeIR {
 }
 
 export function buildOperationIR(slsIR: ServerlessFunctionIR): OperationIR {
-  return {
+  const operation: OperationIR = {
     kind: "operation",
     name: slsIR.name,
     method: slsIR.event.method,
     route: slsIR.event.path,
   }
+
+  const request = slsIR.event.request
+  if (request) {
+    if (typeof request === "string") {
+      operation.requestBody = { ref: request }
+    } else {
+      operation.requestBody = convertType(request)
+    }
+  }
+
+  return operation
 }

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -190,4 +190,31 @@ describe("buildServerlessIR", () => {
       },
     ])
   })
+  it("should handle functions with kebab-case name", () => {
+    const serverless = createServerlessMock({
+      "hello-world": {
+        name: "hello-world",
+        handler: "handler.helloWorld",
+        events: [
+          {
+            http: {
+              method: "get",
+              path: "/hello-world",
+            },
+          },
+        ],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([
+      {
+        kind: "function",
+        name: "helloWorld",
+        event: {
+          method: "get",
+          path: "/hello-world",
+        },
+      },
+    ])
+  })
 })

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -163,4 +163,31 @@ describe("buildServerlessIR", () => {
       },
     ])
   })
+  it("should handle functions with path and no slash starts", () => {
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [
+          {
+            http: {
+              method: "get",
+              path: "hello",
+            },
+          },
+        ],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([
+      {
+        kind: "function",
+        name: "hello",
+        event: {
+          method: "get",
+          path: "/hello",
+        },
+      },
+    ])
+  })
 })

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest"
+import type { SLS } from "../../types/serverless"
+import { buildServerlessIR } from "./build"
+
+describe("buildServerlessIR", () => {
+  it("should build the serverless IR", () => {
+    const serverless = {} as SLS
+    const result = buildServerlessIR(serverless)
+    expect(result).toBeInstanceOf(Array)
+  })
+})

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -29,6 +29,10 @@ describe("buildServerlessIR", () => {
       {
         kind: "function",
         name: "hello",
+        event: {
+          method: "get",
+          path: "/hello",
+        },
       },
     ])
   })
@@ -38,6 +42,39 @@ describe("buildServerlessIR", () => {
         name: "hello",
         handler: "handler.hello",
         events: [],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([])
+  })
+  it("should handle functions with http key only event", () => {
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [
+          {
+            http: "",
+          },
+        ],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([])
+  })
+  it("should handle functions with http event and invalid http method", () => {
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [
+          {
+            http: {
+              method: "invalid",
+              path: "/hello",
+            },
+          },
+        ],
       },
     })
     const result = buildServerlessIR(serverless)
@@ -86,6 +123,10 @@ describe("buildServerlessIR", () => {
       {
         kind: "function",
         name: "hello",
+        event: {
+          method: "get",
+          path: "/hello",
+        },
       },
     ])
   })
@@ -115,6 +156,10 @@ describe("buildServerlessIR", () => {
       {
         kind: "function",
         name: "hello",
+        event: {
+          method: "get",
+          path: "/hello",
+        },
       },
     ])
   })

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -1,11 +1,121 @@
 import { describe, expect, it } from "vitest"
-import type { SLS } from "../../types/serverless"
+import { createServerlessMock } from "../../test/helper"
 import { buildServerlessIR } from "./build"
+import type { ServerlessIR } from "./type"
 
 describe("buildServerlessIR", () => {
   it("should build the serverless IR", () => {
-    const serverless = {} as SLS
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [
+          {
+            http: {
+              method: "get",
+              path: "/hello",
+            },
+          },
+        ],
+      },
+      world: {
+        name: "world",
+        handler: "handler.world",
+        events: [],
+      },
+    })
     const result = buildServerlessIR(serverless)
-    expect(result).toBeInstanceOf(Array)
+    expect(result).toEqual<ServerlessIR[]>([
+      {
+        kind: "function",
+        name: "hello",
+      },
+    ])
+  })
+  it("should handle functions without events", () => {
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([])
+  })
+  it("should handle functions with s3 events", () => {
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [
+          {
+            s3: {
+              bucket: "my-bucket",
+              event: "s3:ObjectCreated:*",
+            },
+          },
+        ],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([])
+  })
+  it("should handle functions with multiple events", () => {
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [
+          {
+            sns: {
+              arn: "arn:aws:sns:us-east-1:123456789012:my-topic",
+            },
+          },
+          {
+            http: {
+              method: "get",
+              path: "/hello",
+            },
+          },
+        ],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([
+      {
+        kind: "function",
+        name: "hello",
+      },
+    ])
+  })
+  it("should handle functions with multiple http events", () => {
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [
+          {
+            http: {
+              method: "get",
+              path: "/hello",
+            },
+          },
+          {
+            http: {
+              method: "post",
+              path: "/hello",
+            },
+          },
+        ],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([
+      {
+        kind: "function",
+        name: "hello",
+      },
+    ])
   })
 })

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -217,4 +217,94 @@ describe("buildServerlessIR", () => {
       },
     ])
   })
+  it("should handle functions with request", () => {
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [
+          {
+            http: {
+              method: "get",
+              path: "/hello",
+              request: {
+                schemas: {
+                  "application/json": {
+                    title: "User",
+                    type: "object",
+                    properties: {
+                      name: {
+                        type: "string",
+                      },
+                      email: {
+                        type: "string",
+                      },
+                    },
+                    required: ["name", "email"],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([
+      {
+        kind: "function",
+        name: "hello",
+        event: {
+          method: "get",
+          path: "/hello",
+          request: {
+            title: "User",
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+              },
+              email: {
+                type: "string",
+              },
+            },
+            required: ["name", "email"],
+          },
+        },
+      },
+    ])
+  })
+  it("should handle functions with request of reference", () => {
+    const serverless = createServerlessMock({
+      hello: {
+        name: "hello",
+        handler: "handler.hello",
+        events: [
+          {
+            http: {
+              method: "get",
+              path: "/hello",
+              request: {
+                schemas: {
+                  "application/json": "user",
+                },
+              },
+            },
+          },
+        ],
+      },
+    })
+    const result = buildServerlessIR(serverless)
+    expect(result).toEqual<ServerlessIR[]>([
+      {
+        kind: "function",
+        name: "hello",
+        event: {
+          method: "get",
+          path: "/hello",
+          request: "user",
+        },
+      },
+    ])
+  })
 })

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -6,8 +6,16 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
 
   for (const functionName of serverless.service.getAllFunctions()) {
     const events = serverless.service.getAllEventsInFunction(functionName)
-    const event = events.find((event) => "http" in event)
+    const event = events.find((event) => "http" in event && event.http)
     if (!event) {
+      // TODO: logging
+      continue
+    }
+    if (!("http" in event) || !event.http) {
+      // TODO: logging
+      continue
+    }
+    if (!isHttpMethod(event.http.method)) {
       // TODO: logging
       continue
     }
@@ -15,8 +23,24 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
     irList.push({
       kind: "function",
       name: functionName,
+      event: {
+        method: event.http.method,
+        path: event.http.path,
+      },
     })
   }
 
   return irList
+}
+
+function isHttpMethod(
+  method: string,
+): method is "get" | "post" | "put" | "delete" | "patch" {
+  return (
+    method === "get" ||
+    method === "post" ||
+    method === "put" ||
+    method === "delete" ||
+    method === "patch"
+  )
 }

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -2,5 +2,21 @@ import type { Serverless } from "../../types/serverless"
 import type { ServerlessIR } from "./type"
 
 export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
-  return []
+  const irList: ServerlessIR[] = []
+
+  for (const functionName of serverless.service.getAllFunctions()) {
+    const events = serverless.service.getAllEventsInFunction(functionName)
+    const event = events.find((event) => "http" in event)
+    if (!event) {
+      // TODO: logging
+      continue
+    }
+
+    irList.push({
+      kind: "function",
+      name: functionName,
+    })
+  }
+
+  return irList
 }

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -25,7 +25,7 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
       name: functionName,
       event: {
         method: event.http.method,
-        path: event.http.path,
+        path: normalizePath(event.http.path),
       },
     })
   }
@@ -43,4 +43,12 @@ function isHttpMethod(
     method === "delete" ||
     method === "patch"
   )
+}
+
+function normalizePath(path: string) {
+  if (!path.startsWith("/")) {
+    return `/${path}`
+  }
+
+  return path
 }

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -22,7 +22,7 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
 
     irList.push({
       kind: "function",
-      name: functionName,
+      name: normalizeFunctionName(functionName),
       event: {
         method: event.http.method,
         path: normalizePath(event.http.path),
@@ -51,4 +51,14 @@ function normalizePath(path: string) {
   }
 
   return path
+}
+
+function normalizeFunctionName(name: string) {
+  return toCamelCase(name)
+}
+
+function toCamelCase(str: string) {
+  return str
+    .replace(/[-_](\w)/g, (_, c) => c.toUpperCase())
+    .replace(/^\w/, (c) => c.toLowerCase())
 }

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -1,0 +1,6 @@
+import type { Serverless } from "../../types/serverless"
+import type { ServerlessIR } from "./type"
+
+export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
+  return []
+}

--- a/packages/serverless-typespec-generator/src/ir/serverless/type.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/type.ts
@@ -3,4 +3,10 @@ export type ServerlessIR = ServerlessFunctionIR
 export type ServerlessFunctionIR = {
   kind: "function"
   name: string
+  event: ServerlessHttpEventIR
+}
+
+export type ServerlessHttpEventIR = {
+  method: "get" | "post" | "put" | "delete" | "patch"
+  path: string
 }

--- a/packages/serverless-typespec-generator/src/ir/serverless/type.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/type.ts
@@ -1,3 +1,5 @@
+import type { JSONSchema } from "../type"
+
 export type ServerlessIR = ServerlessFunctionIR
 
 export type ServerlessFunctionIR = {
@@ -9,4 +11,5 @@ export type ServerlessFunctionIR = {
 export type ServerlessHttpEventIR = {
   method: "get" | "post" | "put" | "delete" | "patch"
   path: string
+  request?: JSONSchema | string
 }

--- a/packages/serverless-typespec-generator/src/ir/serverless/type.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/type.ts
@@ -1,0 +1,6 @@
+export type ServerlessIR = ServerlessFunctionIR
+
+export type ServerlessFunctionIR = {
+  kind: "function"
+  name: string
+}


### PR DESCRIPTION
- **feat: start ServerlessIR implementation**
- **feat: listup functions with http event**
- **feat: handle HTTP events**
- **feat: normalize path**
- **feat: normalize function name**
- **feat: add support for request schemas in serverless IR**
- **feat: start implementation Serverless IR to TypeSpec IR**
- **feat: enhance buildOperationIR to support request schemas**
- **feat: implement buildTypeSpecIR to convert Serverless IR to TypeSpec IR**
- **feat: enhance buildTypeSpecIR to support named request schemas and improve model registration**
