### PR TITLE
More support response in Serverless IR

### DIFF
--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -469,5 +469,80 @@ describe("buildServerlessIR", () => {
         },
       ])
     })
+    it("with reference response model", () => {
+      const serverless = createServerlessMock(
+        {
+          hello: {
+            name: "hello",
+            handler: "handler.hello",
+            events: [
+              {
+                http: {
+                  method: "get",
+                  path: "/hello",
+                  documentation: {
+                    methodResponses: [
+                      {
+                        statusCode: 200,
+                        responseModels: {
+                          "application/json": "user",
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        },
+        {
+          request: {
+            schemas: {
+              user: {
+                name: "User",
+                schema: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                    email: { type: "string" },
+                  },
+                  required: ["name", "email"],
+                },
+              },
+            },
+          },
+        },
+      )
+      const result = buildServerlessIR(serverless)
+      expect(result).toStrictEqual<ServerlessIR[]>([
+        {
+          kind: "model",
+          key: "user",
+          name: "User",
+          schema: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              email: { type: "string" },
+            },
+            required: ["name", "email"],
+          },
+        },
+        {
+          kind: "function",
+          name: "hello",
+          event: {
+            method: "get",
+            path: "/hello",
+            response: [
+              {
+                statusCode: 200,
+                body: "user",
+              },
+            ],
+          },
+        },
+      ])
+    })
   })
 })

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -412,5 +412,62 @@ describe("buildServerlessIR", () => {
         },
       ])
     })
+    it("with anonymous response model", () => {
+      const serverless = createServerlessMock({
+        hello: {
+          name: "hello",
+          handler: "handler.hello",
+          events: [
+            {
+              http: {
+                method: "get",
+                path: "/hello",
+                documentation: {
+                  methodResponses: [
+                    {
+                      statusCode: 200,
+                      responseModels: {
+                        "application/json": {
+                          type: "object",
+                          properties: {
+                            name: { type: "string" },
+                            email: { type: "string" },
+                          },
+                          required: ["name", "email"],
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      })
+      const result = buildServerlessIR(serverless)
+      expect(result).toStrictEqual<ServerlessIR[]>([
+        {
+          kind: "function",
+          name: "hello",
+          event: {
+            method: "get",
+            path: "/hello",
+            response: [
+              {
+                statusCode: 200,
+                body: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                    email: { type: "string" },
+                  },
+                  required: ["name", "email"],
+                },
+              },
+            ],
+          },
+        },
+      ])
+    })
   })
 })

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -412,6 +412,46 @@ describe("buildServerlessIR", () => {
         },
       ])
     })
+    it("with path parameters (documentation)", () => {
+      const serverless = createServerlessMock({
+        hello: {
+          name: "hello",
+          handler: "handler.hello",
+          events: [
+            {
+              http: {
+                method: "get",
+                path: "/hello/:name",
+                documentation: {
+                  pathParams: [
+                    {
+                      name: "name",
+                      schema: { type: "string" },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      })
+      const result = buildServerlessIR(serverless)
+      expect(result).toStrictEqual<ServerlessIR[]>([
+        {
+          kind: "function",
+          name: "hello",
+          event: {
+            method: "get",
+            path: "/hello/:name",
+            request: {
+              path: {
+                name: true,
+              },
+            },
+          },
+        },
+      ])
+    })
     it("with anonymous response model", () => {
       const serverless = createServerlessMock({
         hello: {

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -584,5 +584,72 @@ describe("buildServerlessIR", () => {
         },
       ])
     })
+    it("with named response model", () => {
+      const serverless = createServerlessMock({
+        hello: {
+          name: "hello",
+          handler: "handler.hello",
+          events: [
+            {
+              http: {
+                method: "get",
+                path: "/hello",
+                documentation: {
+                  methodResponses: [
+                    {
+                      statusCode: 200,
+                      responseModels: {
+                        "application/json": {
+                          title: "User",
+                          type: "object",
+                          properties: {
+                            id: { type: "string" },
+                            name: { type: "string" },
+                            email: { type: "string" },
+                          },
+                          required: ["id", "name", "email"],
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      })
+      const result = buildServerlessIR(serverless)
+      expect(result).toStrictEqual<ServerlessIR[]>([
+        {
+          kind: "model",
+          key: "User",
+          name: "User",
+          schema: {
+            title: "User",
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              name: { type: "string" },
+              email: { type: "string" },
+            },
+            required: ["id", "name", "email"],
+          },
+        },
+        {
+          kind: "function",
+          name: "hello",
+          event: {
+            method: "get",
+            path: "/hello",
+            response: [
+              {
+                statusCode: 200,
+                body: "User",
+              },
+            ],
+          },
+        },
+      ])
+    })
   })
 })

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -89,10 +89,30 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
         const statusCode = res.statusCode
         const model = res.responseModels?.["application/json"]
         if (model) {
-          func.event.response.push({
-            statusCode,
-            body: model,
-          })
+          if (typeof model === "string") {
+            func.event.response.push({
+              statusCode,
+              body: model,
+            })
+          } else {
+            if (model.title) {
+              func.event.response.push({
+                statusCode,
+                body: model.title,
+              })
+              irList.push({
+                kind: "model",
+                key: model.title,
+                name: model.title,
+                schema: model,
+              })
+            } else {
+              func.event.response.push({
+                statusCode,
+                body: model,
+              })
+            }
+          }
         }
       }
     }

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -56,7 +56,7 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
 
     const request = http.request
     if (request) {
-      func.event.request = {}
+      func.event.request ??= {}
 
       const requestSchema = request.schemas?.["application/json"]
       if (requestSchema) {
@@ -65,13 +65,23 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
 
       const requestPaths = request.parameters?.paths
       if (requestPaths) {
-        func.event.request.path = {}
+        func.event.request.path ??= {}
         for (const [key, value] of Object.entries(requestPaths)) {
           func.event.request.path[key] =
             typeof value === "object" ? (value.required ?? false) : true
         }
       }
     }
+
+    const pathParams = http.documentation?.pathParams
+    if (pathParams) {
+      func.event.request ??= {}
+      func.event.request.path ??= {}
+      for (const param of pathParams) {
+        func.event.request.path[param.name] = true
+      }
+    }
+
     const responses = http.documentation?.methodResponses
     if (responses) {
       func.event.response = []

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -72,6 +72,20 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
         }
       }
     }
+    const responses = http.documentation?.methodResponses
+    if (responses) {
+      func.event.response = []
+      for (const res of responses) {
+        const statusCode = res.statusCode
+        const model = res.responseModels?.["application/json"]
+        if (model) {
+          func.event.response.push({
+            statusCode,
+            body: model,
+          })
+        }
+      }
+    }
 
     irList.push(func)
   }


### PR DESCRIPTION
- **feat: support anonymous response model**
- **feat: add support for reference response model**
- **feat: add support for documentation.pathParams in Serverless IR**
- **feat: add support for named response model in buildServerlessIR**
