### PR TITLE
Enable tspconfig customize

### DIFF
--- a/packages/serverless-typespec-generator/src/plugin.ts
+++ b/packages/serverless-typespec-generator/src/plugin.ts
@@ -67,6 +67,23 @@ export class ServerlessTypeSpecGenerator implements Plugin {
         await this.generate()
       },
     }
+
+    this.serverless.configSchemaHandler.defineCustomProperties({
+      type: "object",
+      properties: {
+        typespecGenerator: {
+          type: "object",
+          properties: {
+            openapiVersion: {
+              type: "string",
+              description: "OpenAPI version to use for TypeSpec generation",
+              enum: ["3.0.0", "3.1.0"],
+              default: "3.1.0",
+            },
+          },
+        },
+      },
+    })
   }
 
   async generate() {
@@ -82,6 +99,10 @@ export class ServerlessTypeSpecGenerator implements Plugin {
   }
 
   async generateTspConfig(outputDir: string) {
+    const openapiVersion =
+      this.serverless.service.custom?.typespecGenerator?.openapiVersion ||
+      "3.1.0"
+
     await this.serverless.utils.writeFile(
       path.join(outputDir, "tspconfig.yaml"),
       `emit:
@@ -90,7 +111,7 @@ options:
   "@typespec/openapi3":
     emitter-output-dir: "{output-dir}/schema"
     openapi-versions:
-      - 3.1.0
+      - ${openapiVersion}
 `,
     )
   }

--- a/packages/serverless-typespec-generator/src/types/serverless.d.ts
+++ b/packages/serverless-typespec-generator/src/types/serverless.d.ts
@@ -73,11 +73,17 @@ type ServerlessServiceProviderWithSchemas = ReplaceByPath<
   >
 >
 
+type ServiceCustom = {
+  typespecGenerator?: {
+    openapiVersion?: "3.0.0" | "3.1.0"
+  }
+}
+
 export type ServiceWithDoc = Omit<
   Service,
   "custom" | "provider" | "functions" | "getAllEventsInFunction"
 > & {
-  custom?: Service.Custom
+  custom?: ServiceCustom
   provider: ServerlessServiceProviderWithSchemas
   functions: FunctionsWithDocumentation
   getAllEventsInFunction(functionName: string): FunctionEventWithDocumentation[]

--- a/packages/serverless-typespec-generator/src/types/serverless.d.ts
+++ b/packages/serverless-typespec-generator/src/types/serverless.d.ts
@@ -75,8 +75,9 @@ type ServerlessServiceProviderWithSchemas = ReplaceByPath<
 
 export type ServiceWithDoc = Omit<
   Service,
-  "provider" | "functions" | "getAllEventsInFunction"
+  "custom" | "provider" | "functions" | "getAllEventsInFunction"
 > & {
+  custom?: Service.Custom
   provider: ServerlessServiceProviderWithSchemas
   functions: FunctionsWithDocumentation
   getAllEventsInFunction(functionName: string): FunctionEventWithDocumentation[]

--- a/packages/serverless-typespec-generator/src/types/serverless.test-d.ts
+++ b/packages/serverless-typespec-generator/src/types/serverless.test-d.ts
@@ -2,6 +2,8 @@ import { describe, expectTypeOf, it } from "vitest"
 import type { JSONSchema } from "~/types/json-schema"
 import type { Serverless } from "./serverless"
 
+const context = describe
+
 describe("Serverless", () => {
   it("should service.provider.apiGateway be optional", () => {
     expectTypeOf<
@@ -31,5 +33,24 @@ describe("Serverless", () => {
   })
   it("should service.custom be optional", () => {
     expectTypeOf<Serverless["service"]["custom"]>().toBeNullable()
+  })
+  context("service.custom", () => {
+    type ServiceCustom = NonNullable<Serverless["service"]["custom"]>
+
+    it("should typespecGenerator be optional", () => {
+      expectTypeOf<ServiceCustom["typespecGenerator"]>().toBeNullable()
+    })
+    it("should typespecGenerator.openapiVersion be optional", () => {
+      expectTypeOf<
+        NonNullable<ServiceCustom["typespecGenerator"]>["openapiVersion"]
+      >().toBeNullable()
+    })
+    it("should typespecGenerator.openapiVersion be 3.0.0 or 3.1.0", () => {
+      expectTypeOf<
+        NonNullable<
+          NonNullable<ServiceCustom["typespecGenerator"]>["openapiVersion"]
+        >
+      >().toEqualTypeOf<"3.0.0" | "3.1.0">()
+    })
   })
 })

--- a/packages/serverless-typespec-generator/src/types/serverless.test-d.ts
+++ b/packages/serverless-typespec-generator/src/types/serverless.test-d.ts
@@ -29,4 +29,7 @@ describe("Serverless", () => {
     type Schema = Schemas[keyof Schemas]
     expectTypeOf<Schema["schema"]>().toEqualTypeOf<JSONSchema>()
   })
+  it("should service.custom be optional", () => {
+    expectTypeOf<Serverless["service"]["custom"]>().toBeNullable()
+  })
 })

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -28,6 +28,12 @@ for yml in "${ymls[@]}"; do
     echo "fail"
     FAILED_TESTS+=("$yml")
   fi
+  if diff -u --color "$name/expected/tspconfig.yaml" "$name/actual/tspconfig.yaml"; then
+    echo "success"
+  else
+    echo "fail"
+    FAILED_TESTS+=("$yml")
+  fi
 done
 
 if [ ${#FAILED_TESTS[@]} -gt 0 ]; then

--- a/tests/sls-v3/01-basic.yml
+++ b/tests/sls-v3/01-basic.yml
@@ -10,6 +10,10 @@ provider:
   region: ap-northeast-1
   stage: dev
 
+custom:
+  typespecGenerator:
+    openapiVersion: 3.0.0
+
 functions:
   createUser:
     handler: handler.createUser

--- a/tests/sls-v3/01-basic/expected/tspconfig.yaml
+++ b/tests/sls-v3/01-basic/expected/tspconfig.yaml
@@ -1,0 +1,7 @@
+emit:
+  - "@typespec/openapi3"
+options:
+  "@typespec/openapi3":
+    emitter-output-dir: "{output-dir}/schema"
+    openapi-versions:
+      - 3.1.0

--- a/tests/sls-v3/01-basic/expected/tspconfig.yaml
+++ b/tests/sls-v3/01-basic/expected/tspconfig.yaml
@@ -4,4 +4,4 @@ options:
   "@typespec/openapi3":
     emitter-output-dir: "{output-dir}/schema"
     openapi-versions:
-      - 3.1.0
+      - 3.0.0

--- a/tests/sls-v3/02-api-gateway/expected/tspconfig.yaml
+++ b/tests/sls-v3/02-api-gateway/expected/tspconfig.yaml
@@ -1,0 +1,7 @@
+emit:
+  - "@typespec/openapi3"
+options:
+  "@typespec/openapi3":
+    emitter-output-dir: "{output-dir}/schema"
+    openapi-versions:
+      - 3.1.0

--- a/tests/sls-v3/03-path-parameter/expected/tspconfig.yaml
+++ b/tests/sls-v3/03-path-parameter/expected/tspconfig.yaml
@@ -1,0 +1,7 @@
+emit:
+  - "@typespec/openapi3"
+options:
+  "@typespec/openapi3":
+    emitter-output-dir: "{output-dir}/schema"
+    openapi-versions:
+      - 3.1.0

--- a/tests/sls-v3/04-response/expected/tspconfig.yaml
+++ b/tests/sls-v3/04-response/expected/tspconfig.yaml
@@ -1,0 +1,7 @@
+emit:
+  - "@typespec/openapi3"
+options:
+  "@typespec/openapi3":
+    emitter-output-dir: "{output-dir}/schema"
+    openapi-versions:
+      - 3.1.0

--- a/tests/sls-v3/05-complex-schema/expected/tspconfig.yaml
+++ b/tests/sls-v3/05-complex-schema/expected/tspconfig.yaml
@@ -1,0 +1,7 @@
+emit:
+  - "@typespec/openapi3"
+options:
+  "@typespec/openapi3":
+    emitter-output-dir: "{output-dir}/schema"
+    openapi-versions:
+      - 3.1.0


### PR DESCRIPTION
- **test: add expected tspconfig.yaml files for various test cases**
- **test: add specific openapi-version test**
- **feat: conigurable openapiVersion**
- **feat: make service.custom optional**
- **feat: add optional typespecGenerator with openapiVersion to service.custom**
