### PR TITLE
Support request body description

### DIFF
--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -275,7 +275,7 @@ describe("buildServerlessIR", () => {
             method: "get",
             path: "/hello",
             request: {
-              body: "User",
+              body: { schema: "User" },
             },
           },
         },
@@ -310,7 +310,7 @@ describe("buildServerlessIR", () => {
             method: "get",
             path: "/hello",
             request: {
-              body: "user",
+              body: { schema: "user" },
             },
           },
         },

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.test.ts
@@ -715,5 +715,62 @@ describe("buildServerlessIR", () => {
         },
       ])
     })
+    it("with request body description", () => {
+      const serverless = createServerlessMock({
+        hello: {
+          name: "hello",
+          handler: "handler.hello",
+          events: [
+            {
+              http: {
+                method: "post",
+                path: "/hello",
+                request: {
+                  schemas: {
+                    "application/json": {
+                      type: "object",
+                      properties: {
+                        name: { type: "string" },
+                        email: { type: "string" },
+                      },
+                      required: ["name", "email"],
+                    },
+                  },
+                },
+                documentation: {
+                  requestBody: {
+                    description: "User data",
+                  },
+                },
+              },
+            },
+          ],
+        },
+      })
+      const result = buildServerlessIR(serverless)
+      expect(result).toStrictEqual<ServerlessIR[]>([
+        {
+          kind: "function",
+          name: "hello",
+          event: {
+            method: "post",
+            path: "/hello",
+            request: {
+              body: {
+                schema: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                    email: { type: "string" },
+                  },
+                  required: ["name", "email"],
+                },
+                description: "User data",
+              },
+            },
+          },
+        },
+      ])
+    })
   })
 })

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -61,9 +61,9 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
       const requestSchema = request.schemas?.["application/json"]
       if (requestSchema) {
         if (typeof requestSchema === "string") {
-          func.event.request.body = requestSchema
+          func.event.request.body = { schema: requestSchema }
         } else if (requestSchema.title) {
-          func.event.request.body = requestSchema.title
+          func.event.request.body = { schema: requestSchema.title }
           irList.push({
             kind: "model",
             key: requestSchema.title as string,
@@ -71,7 +71,7 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
             schema: requestSchema,
           })
         } else {
-          func.event.request.body = requestSchema
+          func.event.request.body = { schema: requestSchema }
         }
       }
 

--- a/packages/serverless-typespec-generator/src/ir/serverless/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/build.ts
@@ -102,6 +102,18 @@ export function buildServerlessIR(serverless: Serverless): ServerlessIR[] {
       }
     }
 
+    const requestBody = http.documentation?.requestBody
+    if (requestBody) {
+      if (!func.event?.request?.body) {
+        throw new Error(
+          `${functionName} has requestBody but no request body defined`,
+        )
+      }
+      if (requestBody.description) {
+        func.event.request.body.description = requestBody.description
+      }
+    }
+
     const responses = http.documentation?.methodResponses
     if (responses) {
       func.event.responses = []

--- a/packages/serverless-typespec-generator/src/ir/serverless/type.ts
+++ b/packages/serverless-typespec-generator/src/ir/serverless/type.ts
@@ -25,7 +25,10 @@ export type ServerlessHttpEventIR = {
 }
 
 export type ServerlessHttpRequestIR = {
-  body?: JSONSchema | string
+  body?: {
+    schema: JSONSchema | string
+    description?: string
+  }
   path?: Record<string, boolean>
   // query?: Record<string, boolean>
   // headers?: Record<string, boolean>

--- a/packages/serverless-typespec-generator/src/ir/typespec/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/build.test.ts
@@ -287,9 +287,11 @@ describe("buildTypeSpecIR", () => {
             path: "/hello",
             request: {
               body: {
-                type: "object",
-                properties: {
-                  name: { type: "string" },
+                schema: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                  },
                 },
               },
             },
@@ -515,7 +517,7 @@ describe("buildTypeSpecIR", () => {
             method: "get",
             path: "/hello",
             request: {
-              body: "user",
+              body: { schema: "user" },
             },
           },
         },
@@ -571,12 +573,14 @@ describe("buildOperationIR", () => {
           path: "/hello",
           request: {
             body: {
-              type: "object",
-              properties: {
-                name: { type: "string" },
-                email: { type: "string" },
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  email: { type: "string" },
+                },
+                required: ["name", "email"],
               },
-              required: ["name", "email"],
             },
           },
         },
@@ -604,7 +608,7 @@ describe("buildOperationIR", () => {
           method: "get",
           path: "/hello",
           request: {
-            body: "User",
+            body: { schema: "User" },
           },
         },
       }

--- a/packages/serverless-typespec-generator/src/ir/typespec/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/build.test.ts
@@ -862,5 +862,40 @@ describe("buildOperationIR", () => {
         route: "/hello",
       })
     })
+    it("with request body description", () => {
+      const slsIR: ServerlessFunctionIR = {
+        kind: "function",
+        name: "hello",
+        event: {
+          method: "post",
+          path: "/hello",
+          request: {
+            body: {
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                },
+              },
+              description: "Request body for hello",
+            },
+          },
+        },
+      }
+      const result = buildOperationIR(slsIR, new Registry<TypeSpecIR>())
+      expect(result).toStrictEqual<TypeSpecOperationIR>({
+        kind: "operation",
+        name: "hello",
+        method: "post",
+        route: "/hello",
+        requestBody: {
+          type: {
+            name: { type: "string", required: false },
+          },
+          required: true,
+          description: "Request body for hello",
+        },
+      })
+    })
   })
 })

--- a/packages/serverless-typespec-generator/src/ir/typespec/build.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/build.test.ts
@@ -304,7 +304,10 @@ describe("buildTypeSpecIR", () => {
           method: "post",
           route: "/hello",
           requestBody: {
-            name: { type: "string", required: false },
+            type: {
+              name: { type: "string", required: false },
+            },
+            required: true,
           },
         },
       ])
@@ -524,7 +527,7 @@ describe("buildTypeSpecIR", () => {
           name: "hello",
           method: "get",
           route: "/hello",
-          requestBody: { ref: "User" },
+          requestBody: { type: { ref: "User" }, required: true },
         },
         {
           kind: "model",
@@ -585,8 +588,11 @@ describe("buildOperationIR", () => {
         method: "post",
         route: "/hello",
         requestBody: {
-          name: { type: "string", required: true },
-          email: { type: "string", required: true },
+          type: {
+            name: { type: "string", required: true },
+            email: { type: "string", required: true },
+          },
+          required: true,
         },
       })
     })
@@ -608,7 +614,7 @@ describe("buildOperationIR", () => {
         name: "hello",
         method: "get",
         route: "/hello",
-        requestBody: { ref: "User" },
+        requestBody: { type: { ref: "User" }, required: true },
       })
     })
     it("with path parameters", () => {

--- a/packages/serverless-typespec-generator/src/ir/typespec/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/build.ts
@@ -162,14 +162,14 @@ export function buildOperationIR(
   if (request) {
     const body = request.body
     if (body) {
-      if (typeof body === "string") {
+      if (typeof body.schema === "string") {
         operation.requestBody = {
-          type: { ref: modelRef(body) },
+          type: { ref: modelRef(body.schema) },
           required: true,
         }
       } else {
         operation.requestBody = {
-          type: convertType(body),
+          type: convertType(body.schema),
           required: true,
         }
       }

--- a/packages/serverless-typespec-generator/src/ir/typespec/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/build.ts
@@ -173,6 +173,9 @@ export function buildOperationIR(
           required: true,
         }
       }
+      if (body.description) {
+        operation.requestBody.description = body.description
+      }
     }
     const pathParams = request.path
     if (pathParams) {

--- a/packages/serverless-typespec-generator/src/ir/typespec/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/build.ts
@@ -163,9 +163,15 @@ export function buildOperationIR(
     const body = request.body
     if (body) {
       if (typeof body === "string") {
-        operation.requestBody = { ref: modelRef(body) }
+        operation.requestBody = {
+          type: { ref: modelRef(body) },
+          required: true,
+        }
       } else {
-        operation.requestBody = convertType(body)
+        operation.requestBody = {
+          type: convertType(body),
+          required: true,
+        }
       }
     }
     const pathParams = request.path

--- a/packages/serverless-typespec-generator/src/ir/typespec/emit.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/emit.test.ts
@@ -20,7 +20,10 @@ describe("emitTypeSpec", () => {
         name: "createUser",
         method: "post",
         route: "/users",
-        requestBody: { ref: "CreateUserRequest" },
+        requestBody: {
+          type: { ref: "CreateUserRequest" },
+          required: true,
+        },
         returnType: [
           {
             statusCode: 201,
@@ -101,8 +104,11 @@ describe("emitIR", () => {
         method: "post",
         route: "/users",
         requestBody: {
-          name: { type: "string", required: true },
-          email: { type: "string", required: true },
+          type: {
+            name: { type: "string", required: true },
+            email: { type: "string", required: true },
+          },
+          required: true,
         },
         returnType: {
           id: { type: "string", required: true },
@@ -301,8 +307,11 @@ describe("emitOperation", () => {
         method: "post",
         route: "/users",
         requestBody: {
-          name: { type: "string", required: true },
-          email: { type: "string", required: true },
+          type: {
+            name: { type: "string", required: true },
+            email: { type: "string", required: true },
+          },
+          required: true,
         },
         returnType: {
           id: { type: "string", required: true },

--- a/packages/serverless-typespec-generator/src/ir/typespec/emit.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/emit.test.ts
@@ -563,5 +563,45 @@ describe("emitOperation", () => {
         };
       `)
     })
+    it("with request body description", async () => {
+      const operation: TypeSpecOperationIR = {
+        kind: "operation",
+        name: "createUser",
+        method: "post",
+        route: "/users",
+        requestBody: {
+          type: {
+            name: { type: "string", required: true },
+            email: { type: "string", required: true },
+          },
+          required: true,
+          description: "Create a new user",
+        },
+        returnType: {
+          id: { type: "string", required: true },
+          name: { type: "string", required: true },
+          email: { type: "string", required: true },
+        },
+      }
+      const result = emitOperation(operation)
+      expect(await normalizeTypeSpec(result)).toBe(dedent`
+        @route("/users")
+        @post
+        op createUser(
+          @doc("""
+            Create a new user
+            """)
+          @body
+          body: {
+            name: string;
+            email: string;
+          },
+        ): {
+          id: string;
+          name: string;
+          email: string;
+        };
+      `)
+    })
   })
 })

--- a/packages/serverless-typespec-generator/src/ir/typespec/emit.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/emit.ts
@@ -73,18 +73,43 @@ export function emitModel(model: TypeSpecModelIR): string {
 export function emitOperation(operation: TypeSpecOperationIR): string {
   const lines: string[] = []
 
+  const emitParameter = (
+    decorators: string[],
+    name: string,
+    type: string,
+    required: boolean,
+  ): string => {
+    const decoratorString = decorators.join("\n")
+    const optional = required ? "" : "?"
+    return `${decoratorString} ${name}${optional}: ${type}`
+  }
+
   const parameters: string[] = []
   const paramEntries = Object.entries(operation.parameters ?? {})
   const pathParams = new Set(operation.http?.params ?? [])
   for (const [name, prop] of paramEntries) {
-    const decorator = pathParams.has(name) ? "@path" : ""
-    const optional = prop.required ? "" : "?"
+    const decorators = pathParams.has(name) ? ["@path"] : []
     const type = renderType(prop.type)
-    parameters.push(`${decorator} ${name}${optional}: ${type}`)
+    parameters.push(emitParameter(decorators, name, type, prop.required))
   }
 
   if (operation.requestBody) {
-    parameters.push(`@body body: ${renderType(operation.requestBody.type)}`)
+    const decorators: string[] = []
+    if (operation.requestBody.description) {
+      decorators.push('@doc("""')
+      decorators.push(operation.requestBody.description)
+      decorators.push('""")')
+    }
+    decorators.push("@body")
+
+    parameters.push(
+      emitParameter(
+        decorators,
+        "body",
+        renderType(operation.requestBody.type),
+        true,
+      ),
+    )
   }
 
   let returnType = "void"
@@ -106,7 +131,9 @@ export function emitOperation(operation: TypeSpecOperationIR): string {
   }
   lines.push(`@route("${operation.route}")`)
   lines.push(`@${operation.method}`)
-  lines.push(`op ${operation.name}(${parameters.join(", ")}): ${returnType};`)
+  lines.push(`op ${operation.name}(`)
+  lines.push(parameters.join(", "))
+  lines.push(`): ${returnType};`)
 
   return lines.join("\n")
 }

--- a/packages/serverless-typespec-generator/src/ir/typespec/emit.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/emit.ts
@@ -84,7 +84,7 @@ export function emitOperation(operation: TypeSpecOperationIR): string {
   }
 
   if (operation.requestBody) {
-    parameters.push(`@body body: ${renderType(operation.requestBody)}`)
+    parameters.push(`@body body: ${renderType(operation.requestBody.type)}`)
   }
 
   let returnType = "void"

--- a/packages/serverless-typespec-generator/src/ir/typespec/type.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/type.ts
@@ -20,7 +20,7 @@ export type TypeSpecOperationIR = {
   method: "get" | "post" | "put" | "delete" | "patch"
   route: string
   parameters?: Record<string, PropIR>
-  requestBody?: PropTypeIR
+  requestBody?: PropIR
   returnType?: PropTypeIR | HttpResponseIR[]
 
   http?: {

--- a/packages/serverless-typespec-generator/src/types/serverless.d.ts
+++ b/packages/serverless-typespec-generator/src/types/serverless.d.ts
@@ -25,6 +25,10 @@ export type HttpEventDocumentation = {
     name: string
     schema: { type: "string" }
   }[]
+  requestBody?: {
+    description?: string
+    required?: boolean
+  }
   methodResponses?: {
     statusCode: number
     responseModels?: {

--- a/tests/sls-v3/01-basic.yml
+++ b/tests/sls-v3/01-basic.yml
@@ -42,3 +42,8 @@ functions:
               Create a user with the given name and email.
 
               This is a multi-line description.
+            requestBody:
+              description: |-
+                User object to create.
+
+                This is a multi-line description.

--- a/tests/sls-v3/01-basic/expected/main.tsp
+++ b/tests/sls-v3/01-basic/expected/main.tsp
@@ -13,7 +13,15 @@ namespace GeneratedApi;
   """)
 @route("/users")
 @post
-op createUser(@body body: User): void;
+op createUser(
+  @doc("""
+    User object to create.
+    
+    This is a multi-line description.
+    """)
+  @body
+  body: User,
+): void;
 
 model User {
   @doc("""


### PR DESCRIPTION
- **test: request body description**
- **feat: add requestBody property to HttpEventDocumentation type**
- **feat: update requestBody structure to include type and required properties**
- **feat: add request body description support in emitOperation**
- **feat: update request body structure to use schema property**
- **feat: add request body description handling in buildServerlessIR**
- **feat: update request body handling in buildOperationIR to use schema property**
- **feat: add request body description support in buildOperationIR**
