### PR TITLE
Fix escaping of quotes in pattern decorator

### DIFF
--- a/packages/serverless-typespec-generator/src/ir/typespec/emit.test.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/emit.test.ts
@@ -372,6 +372,25 @@ describe("emitModel", () => {
         }
       `)
     })
+    it("with pattern containing quotes", async () => {
+      const model: TypeSpecModelIR = {
+        kind: "model",
+        name: "QuotePatternModel",
+        props: {
+          value: {
+            type: { __pattern: "^foo\"bar$", type: "string" },
+            required: true,
+          },
+        },
+      }
+      const result = emitModel(model)
+      expect(await normalizeTypeSpec(result)).toBe(dedent`
+        model QuotePatternModel {
+          @pattern("^foo\"bar$")
+          value: string;
+        }
+      `)
+    })
     it("with literal type", async () => {
       const model: TypeSpecModelIR = {
         kind: "model",

--- a/packages/serverless-typespec-generator/src/ir/typespec/emit.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/emit.ts
@@ -211,5 +211,5 @@ function unwrapDecorators(t: PropTypeIR): {
 }
 
 function escapeRegExp(str: string): string {
-  return str.replace(/\\/g, "\\\\")
+  return str.replace(/\\/g, "\\\\").replace(/"/g, "\\\"")
 }


### PR DESCRIPTION
## Summary
- escape double quotes in regex patterns correctly
- add regression test for patterns containing quotes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683f999e91c08330bb20486354bd6c62