### PR TITLE
Remove unused exports

### DIFF
--- a/packages/serverless-typespec-generator/src/ir/typespec/build.ts
+++ b/packages/serverless-typespec-generator/src/ir/typespec/build.ts
@@ -209,7 +209,7 @@ function buildArrayType(schema: JSONSchema): PropTypeIR[] {
   return [convertType(schema.items)]
 }
 
-export function extractProps(schema: JSONSchema): PropsType {
+function extractProps(schema: JSONSchema): PropsType {
   if (schema.allOf) {
     return mergeAllOfObjectSchemas(schema.allOf)
   }

--- a/packages/serverless-typespec-generator/src/registry.ts
+++ b/packages/serverless-typespec-generator/src/registry.ts
@@ -1,4 +1,4 @@
-export class AlreadyRegisteredError extends Error {}
+class AlreadyRegisteredError extends Error {}
 
 export class Registry<T> {
   private store: Map<string, T>


### PR DESCRIPTION
## Summary
- remove `export` from AlreadyRegisteredError class
- remove `export` from `extractProps` function

## Testing
- `pnpm lint`
- `pnpm -F serverless-typespec-generator build`
- `pnpm test`
- `tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_6843b04a10f083308ed2b9517f28d618